### PR TITLE
Recognize that some papers have used {quote} for {abstract} 

### DIFF
--- a/css/ar5iv.css
+++ b/css/ar5iv.css
@@ -1077,6 +1077,22 @@ blockquote.ltx_epigraph {
   margin-left: calc(0.45*var(--main-width)) !important;
 }
 
+/* Exception: some articles carelessly use {quote} instead of abstract */
+/* see ar5iv#253 and ar5iv-css#3 for examples */
+.ltx_authors + .ltx_para:has(+ .ltx_section) > blockquote.ltx_quote:only-child,
+.ltx_titlepage:not(:has(.ltx_abstract)) > blockquote.ltx_quote:last-child,
+.ltx_abstract > .ltx_title_abstract + blockquote.ltx_quote:last-child {
+    max-width: 90%;
+    margin: auto;
+    border-left: initial;
+    font-size: initial;
+    font-style: initial;
+    line-height: initial;
+    padding: initial;
+    position: initial;
+    z-index: initial;
+}
+
 /* ================================= */
 /* from LaTeXML.css, possibly edited */
 /* ================================= */


### PR DESCRIPTION
Tested against the examples listed in #3 , and addresses a problem reported in [ar5iv#253](https://github.com/dginev/ar5iv/issues/253).

I don't think there is a reasonable way to do this in CSS without reaching for the power of `:has` selectors. At least it would be prone to over-select actual quotation that start a document the intentionally does **not** have an abstract.

I think the three cases I have covered here, while heuristic, should be mostly on the money. 

And if they are not - we can revisit later.