### PR TITLE
Save space for mobile bibtex

### DIFF
--- a/css/ar5iv.css
+++ b/css/ar5iv.css
@@ -938,6 +938,7 @@ span.ltx_font_bold > .ltx_break:last-child {
 }
 @media only screen and (max-width: 52rem) {
   .ltx_bibitem .ltx_tag {
+    display: block;
     width: 26%;
   }
 }


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/4687791/222765083-8f595fb3-3025-40c4-a558-4a84372ed929.png)

After

![image](https://user-images.githubusercontent.com/4687791/222765113-9a5ff85b-b895-49cb-8373-509394b1261a.png)

I tried it on https://ar5iv.labs.arxiv.org/html/2203.03456