### PR TITLE
Refactor latexml CSS var names for foreign object dimensions

### DIFF
--- a/css/ar5iv.css
+++ b/css/ar5iv.css
@@ -1697,14 +1697,14 @@ svg .ltx_foreignobject_content {
   text-align: left; }
 foreignObject {
   /* translate: 0 0.1em; */
-  --fo_width: 100%;
+  --ltx-fo-width: 100%;
 }
 /* Use flex to vertically center foreignObject,
    to accommodate potentially tall line-box */
 svg foreignObject > .ltx_foreignobject_container {
   display: flex;
   align-items: end; /* see examples from latexml PR #2541 */
-  width: clamp(calc(0.1 * var(--main-width)), var(--fo_width), 100%);
+  width: clamp(calc(0.1 * var(--main-width)), var(--ltx-fo-width), 100%);
   height: 100%;
 }
 svg foreignObject > .ltx_foreignobject_container {
@@ -1718,7 +1718,7 @@ svg foreignObject > .ltx_foreignobject_container {
   /* If multiple children, give more space to avoid unexpected line breaks
    due to font differences. */
   &:has(> .ltx_foreignobject_content > :not(:only-child)) {
-    width: calc(1.1 * var(--fo_width));
+    width: calc(1.1 * var(--ltx-fo-width));
   }
   & > .ltx_foreignobject_content {
     display: block;


### PR DESCRIPTION
This tracks the naming changes from https://github.com/brucemiller/LaTeXML/pull/2680