### PR TITLE
[nav ToC] pad abstract, acknowledgements, references

### DIFF
--- a/css/ar5iv.css
+++ b/css/ar5iv.css
@@ -949,7 +949,8 @@ ul.ltx_toclist > .ltx_tocentry:first-of-type {
 }
 .ltx_tocentry_part > .ltx_ref > .ltx_ref_title > .ltx_tag,
 .ltx_tocentry_chapter > .ltx_ref > .ltx_ref_title > .ltx_tag,
-.ltx_tocentry_section > .ltx_ref > .ltx_ref_title > .ltx_tag {
+.ltx_tocentry_section > .ltx_ref > .ltx_ref_title > .ltx_tag,
+.ltx_tocentry_appendix > .ltx_ref > .ltx_ref_title > .ltx_tag {
   margin-right: 1rem;
   display: inline-block;
   min-width: 1.5rem;
@@ -966,13 +967,15 @@ ul.ltx_toclist > .ltx_tocentry:first-of-type {
 
 .ltx_tocentry_part .ltx_tocentry_chapter > .ltx_ref,
 .ltx_tocentry_chapter .ltx_tocentry_section > .ltx_ref > .ltx_ref_title,
-.ltx_tocentry_subsection > .ltx_ref > .ltx_ref_title {
+.ltx_tocentry_subsection > .ltx_ref > .ltx_ref_title,
+.ltx_tocentry_appendix > .ltx_ref > .ltx_ref_title {
   font-family: var(--text-font-family);
 }
 .ltx_tocentry_part .ltx_tocentry_chapter > .ltx_ref,
 .ltx_tocentry_chapter .ltx_tocentry_section > .ltx_ref,
 .ltx_tocentry_subsection > .ltx_ref,
-.ltx_tocentry_subsubsection > .ltx_ref {
+.ltx_tocentry_subsubsection > .ltx_ref,
+.ltx_tocentry_appendix > .ltx_ref > .ltx_ref_title {
   border-bottom: none;
 }
 
@@ -995,9 +998,10 @@ ul.ltx_toclist > .ltx_tocentry:first-of-type {
   margin-right: 0.3rem;
 }
 
-/* A (topl evel) tocentry without tags should still have an equivalent padding to align well */
+/* A (top level) tocentry without tags should still have an equivalent padding to align well */
 .ltx_toclist > .ltx_tocentry_abstract, 
 .ltx_toclist > .ltx_tocentry_acknowledgements, 
+.ltx_toclist > .ltx_tocentry_paragraph, 
 .ltx_toclist > .ltx_tocentry_bibliography {
   margin-left: 2.5rem;
 }


### PR DESCRIPTION
Give equal padding to ToC entries which do not carry a visible tag.

This is an extension continuing #33 